### PR TITLE
Execute helper methods in a separate helper context

### DIFF
--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -124,6 +124,16 @@ module Haparanda
       end
     end
 
+    class HelperContext
+      def initialize(input)
+        @input = input
+      end
+
+      def this
+        @input
+      end
+    end
+
     def initialize(input, custom_helpers = nil, data: {})
       super()
 
@@ -131,6 +141,7 @@ module Haparanda
 
       @input = Input.new(input)
       @data = data ? Data.new(data) : NoData.new
+      @helper_context = HelperContext.new(@input)
 
       custom_helpers ||= {}
       @helpers = {
@@ -290,7 +301,7 @@ module Haparanda
 
       args = [*params, Options.new(fn: fn, inverse: inverse, hash: hash, data: @data)]
       args = args.take(num_params)
-      @input.instance_exec(*args, &callable)
+      @helper_context.instance_exec(*args, &callable)
     end
 
     def handle_if(value, options)

--- a/test/compatibility/helpers_test.rb
+++ b/test/compatibility/helpers_test.rb
@@ -107,8 +107,8 @@ describe 'helpers' do
     expectTemplate('{{#goodbyes}}{{../name}}{{/goodbyes}}')
       .withInput({ name: 'Alan' })
       .withHelper('goodbyes', lambda { |options|
-        var out = '';
-        var byes = ['Goodbye', 'goodbye', 'GOODBYE'];
+        out = '';
+        byes = ['Goodbye', 'goodbye', 'GOODBYE'];
         byes.length.times do |i|
           out += byes[i] + ' ' + options.fn({}) + '! ';
         end
@@ -260,7 +260,7 @@ describe 'helpers' do
     string = "{{#list people}}{{name}}{{^}}<em>Nobody's here</em>{{/list}}";
     list = lambda { |context, options|
       if context.length > 0
-        var out = '<ul>';
+        out = '<ul>';
         context.length.times do |i|
           out += '<li>';
           out += options.fn(context[i]);


### PR DESCRIPTION
Executing these methods in the context of an Input object makes any unknown method be silently ignored, while the only relevant method called in helpers is 'this'. To catch undefined methods called in helpers, instead a new HelperContext object is introduced, that just provides the 'this' method.
