### PR TITLE
Finalize implementation of whitespace handling

### DIFF
--- a/lib/haparanda/whitespace_handler.rb
+++ b/lib/haparanda/whitespace_handler.rb
@@ -57,10 +57,9 @@ module Haparanda
 
       case statements.sexp_type
       when :statements
-        if (items = statements&.sexp_body)
-          strip_initial_whitespace(items.first, open_strip)
-          strip_final_whitespace(items.last, close_strip)
-        end
+        items = statements.sexp_body
+        strip_initial_whitespace(items.first, open_strip)
+        strip_final_whitespace(items.last, close_strip)
       end
       # TODO: Handle :block sexp_type
 

--- a/lib/haparanda/whitespace_handler.rb
+++ b/lib/haparanda/whitespace_handler.rb
@@ -70,6 +70,13 @@ module Haparanda
     def process_statements(expr)
       statements = expr.sexp_body
 
+      statements.each_cons(3) do |prev, partial, item|
+        next if partial.sexp_type != :partial
+        next unless preceding_whitespace? prev
+
+        strip_initial_whitespace(item, s(:strip, true, true))
+      end
+
       statements.each_cons(2) do |prev, item|
         strip_final_whitespace(prev, open_strip_for(item)) if item.sexp_type != :content
         strip_initial_whitespace(item, close_strip_for(prev)) if prev.sexp_type != :content

--- a/test/compatibility/whitespace_control_test.rb
+++ b/test/compatibility/whitespace_control_test.rb
@@ -129,7 +129,6 @@ describe 'whitespace control' do
   end
 
   it 'should strip whitespace around partials' do
-    skip
     expectTemplate('foo {{~> dude~}} ')
       .withPartials({ dude: 'bar' })
       .toCompileTo('foobar');

--- a/test/compatibility/whitespace_control_test.rb
+++ b/test/compatibility/whitespace_control_test.rb
@@ -152,7 +152,6 @@ describe 'whitespace control' do
   end
 
   it 'should only strip whitespace once' do
-    skip
     expectTemplate(' {{~foo~}} {{foo}} {{foo}} ')
       .withInput({ foo: 'bar' })
       .toCompileTo('barbar bar ');


### PR DESCRIPTION
With these changes, all tests in whitespace_control_test pass.

- **Enable passing whitespace control test**
- **Strip whitespace after partials that appear on their own line**
- **Break apart complex method WhitespaceHandler#process_statements**
- **Remove needless condition**
