### PR TITLE
Implement helperMissing functionality

### DIFF
--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -220,7 +220,11 @@ module Haparanda
       hash = process(hash)[1] if hash
       data, elements = path_segments process(path)
       value = lookup_path(data, elements)
-      value = execute_in_context(value, params, hash: hash) if value.respond_to? :call
+      if value.respond_to? :call
+        value = execute_in_context(value, params, hash: hash)
+      elsif !params.empty?
+        raise "Missing helper: \"#{elements.first}\""
+      end
       value = value.to_s
       value = Utils.escape(value) if escaped
       s(:result, value)

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -221,15 +221,13 @@ module Haparanda
       hash = process(hash)[1] if hash
       value, name = lookup_value process(path)
 
+      if value.nil?
+        value = @helpers[:helper_missing]
+        raise "Missing helper: \"#{name}\"" if value.nil? && !params.empty?
+      end
+
       if value.respond_to? :call
         value = execute_in_context(value, params, name: name, hash: hash)
-      elsif !params.empty?
-        value = @helpers[:helper_missing] or raise "Missing helper: \"#{name}\""
-
-        value = execute_in_context(value, params, name: name, hash: hash)
-      elsif value.nil?
-        value = @helpers[:helper_missing]
-        value = execute_in_context(value, params, name: name, hash: hash) if value
       end
 
       value = value.to_s

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -117,15 +117,16 @@ module Haparanda
     end
 
     class Options
-      def initialize(fn:, inverse:, hash:, data:, block_params:)
+      def initialize(fn:, inverse:, hash:, data:, block_params:, name: nil)
         @fn = fn
         @inverse = inverse
+        @name = name
         @hash = hash
         @data = data
         @block_params = block_params
       end
 
-      attr_reader :hash, :data, :block_params
+      attr_reader :name, :hash, :data, :block_params
 
       def fn(arg = nil, options = {})
         @fn&.call(arg, options)
@@ -218,12 +219,11 @@ module Haparanda
       _, path, params, hash, escaped, _strip = expr
       params = process(params)[1]
       hash = process(hash)[1] if hash
-      data, elements = path_segments process(path)
-      value = lookup_path(data, elements)
+      value, name = lookup_value process(path)
       if value.respond_to? :call
-        value = execute_in_context(value, params, hash: hash)
+        value = execute_in_context(value, params, name: name, hash: hash)
       elsif !params.empty?
-        raise "Missing helper: \"#{elements.first}\""
+        raise "Missing helper: \"#{name}\""
       end
       value = value.to_s
       value = Utils.escape(value) if escaped
@@ -407,6 +407,13 @@ module Haparanda
       end
     end
 
+    def lookup_value(path)
+      data, elements = path_segments(path)
+      value = lookup_path(data, elements)
+      name = elements.last
+      return value, name
+    end
+
     def path_segments(path)
       case path.sexp_type
       when :segments
@@ -431,7 +438,7 @@ module Haparanda
       end
     end
 
-    def execute_in_context(callable, params = [],
+    def execute_in_context(callable, params = [], name: nil,
                            fn: nil, inverse: nil, block_params: 0, hash: nil)
       arity = callable.arity
       num_params = params.count
@@ -439,7 +446,8 @@ module Haparanda
 
       params = params.take(arity) if num_params > arity
 
-      options = Options.new(fn: fn, inverse: inverse,
+      options = Options.new(name: name,
+                            fn: fn, inverse: inverse,
                             block_params: block_params, hash: hash,
                             data: @data)
       params.push options if arity > num_params

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -222,7 +222,7 @@ module Haparanda
       value, name = lookup_value process(path)
 
       if value.nil?
-        value = @helpers[:helper_missing]
+        value = @helpers[:helperMissing]
         raise "Missing helper: \"#{name}\"" if value.nil? && !params.empty?
       end
 

--- a/test/compatibility/helpers_test.rb
+++ b/test/compatibility/helpers_test.rb
@@ -657,8 +657,8 @@ describe 'helpers' do
 
   describe 'helperMissing' do
     it 'if a context is not found, helperMissing is used' do
-      skip
       expectTemplate('{{hello}} {{link_to world}}').toThrow(
+        RuntimeError,
         /Missing helper: "link_to"/
       );
     end

--- a/test/compatibility/helpers_test.rb
+++ b/test/compatibility/helpers_test.rb
@@ -675,12 +675,11 @@ describe 'helpers' do
     end
 
     it 'if a value is not found, custom helperMissing is used' do
-      skip
       expectTemplate('{{hello}} {{link_to}}')
         .withInput({ hello: 'Hello', world: 'world' })
-        .withHelper('helperMissing', lambda { |options|
-          if options.name == 'link_to'
-            return new Handlebars.SafeString('<a>winning</a>');
+        .withHelper('helper_missing', lambda { |options|
+          if options.name == :link_to
+            return Haparanda::HandlebarsProcessor::SafeString.new('<a>winning</a>');
           end
         })
         .toCompileTo('Hello <a>winning</a>');

--- a/test/compatibility/helpers_test.rb
+++ b/test/compatibility/helpers_test.rb
@@ -666,7 +666,7 @@ describe 'helpers' do
     it 'if a context is not found, custom helperMissing is used' do
       expectTemplate('{{hello}} {{link_to world}}')
         .withInput({ hello: 'Hello', world: 'world' })
-        .withHelper('helper_missing', lambda { |mesg, options|
+        .withHelper('helperMissing', lambda { |mesg, options|
           if options.name == :link_to
             return Haparanda::HandlebarsProcessor::SafeString.new('<a>' + mesg + '</a>');
           end
@@ -677,7 +677,7 @@ describe 'helpers' do
     it 'if a value is not found, custom helperMissing is used' do
       expectTemplate('{{hello}} {{link_to}}')
         .withInput({ hello: 'Hello', world: 'world' })
-        .withHelper('helper_missing', lambda { |options|
+        .withHelper('helperMissing', lambda { |options|
           if options.name == :link_to
             return Haparanda::HandlebarsProcessor::SafeString.new('<a>winning</a>');
           end

--- a/test/compatibility/helpers_test.rb
+++ b/test/compatibility/helpers_test.rb
@@ -664,12 +664,11 @@ describe 'helpers' do
     end
 
     it 'if a context is not found, custom helperMissing is used' do
-      skip
       expectTemplate('{{hello}} {{link_to world}}')
         .withInput({ hello: 'Hello', world: 'world' })
-        .withHelper('helperMissing', lambda { |mesg, options|
-          if options.name == 'link_to'
-            return new Handlebars.SafeString('<a>' + mesg + '</a>');
+        .withHelper('helper_missing', lambda { |mesg, options|
+          if options.name == :link_to
+            return Haparanda::HandlebarsProcessor::SafeString.new('<a>' + mesg + '</a>');
           end
         })
         .toCompileTo('Hello <a>world</a>');

--- a/test/integration/helpers_test.rb
+++ b/test/integration/helpers_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe "helpers" do
+  let(:compiler) { Haparanda::Compiler.new }
+  describe "the options parameter" do
+    it "has its name attribute set for mustaches" do
+      compiler.register_helper("foo") { |options| "#{options.name}bar" }
+      result = compiler.compile("{{foo}}").call({})
+
+      _(result).must_equal "foobar"
+    end
+  end
+end

--- a/test/integration/helpers_test.rb
+++ b/test/integration/helpers_test.rb
@@ -4,12 +4,22 @@ require "test_helper"
 
 describe "helpers" do
   let(:compiler) { Haparanda::Compiler.new }
+
   describe "the options parameter" do
     it "has its name attribute set for mustaches" do
       compiler.register_helper("foo") { |options| "#{options.name}bar" }
       result = compiler.compile("{{foo}}").call({})
 
       _(result).must_equal "foobar"
+    end
+
+    it "has its name attribute set for blocks" do
+      compiler.register_helper("foo") do |options|
+        "#{options.name}#{options.fn}#{options.name}"
+      end
+      result = compiler.compile("{{#foo}}bar{{/foo}}").call({})
+
+      _(result).must_equal "foobarfoo"
     end
   end
 end


### PR DESCRIPTION
This raises an error when a helper is missing and adds support for use of a custom helperMissing helper.

- **Raise an error when helper is missing**
- **Pass helper name to helper in options parameter for mustaches**
- **Pass helper name to helper in options parameter for blocks**
- **Allow specifying a custom helper_missing helper**
- **Call custom helper_missing for missing plain values**
- **Simplify logic for handling of missing values**
- **Match original Handlebars naming convention for helperMissing**
