### PR TITLE
Provide clear error message when required helper arguments are missing

### DIFF
--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -445,7 +445,7 @@ module Haparanda
       arity = callable.arity
       num_params = params.count
       arity = num_params + 2 if arity < 0
-      raise ArgumentError, "expected #{arity - 2} arguments" if arity > num_params + 2
+      raise_arity_error(arity, name, is_block: !fn.nil?) if arity > num_params + 2
 
       params = params.take(arity) if num_params > arity
 
@@ -458,6 +458,13 @@ module Haparanda
       result = @helper_context.instance_exec(*params, &callable)
       result = fn.call(result) if fn && arity <= num_params
       result
+    end
+
+    def raise_arity_error(arity, name, is_block: false)
+      expected = arity - 2
+      identifier = is_block ? "##{name}" : name
+      raise ArgumentError,
+            "Expected #{expected} argument#{'s' if expected > 1} for #{identifier}"
     end
 
     def handle_if(context, value, options)

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -448,6 +448,7 @@ module Haparanda
       arity = callable.arity
       num_params = params.count
       arity = num_params + 2 if arity < 0
+      raise ArgumentError, "expected #{arity - 2} arguments" if arity > num_params + 2
 
       params = params.take(arity) if num_params > arity
 

--- a/test/compatibility/builtins_test.rb
+++ b/test/compatibility/builtins_test.rb
@@ -518,7 +518,7 @@ describe 'builtin helpers' do
     it 'each on implicit context' do
       expectTemplate('{{#each}}{{text}}! {{/each}}cruel world!').toThrow(
         ArgumentError,
-        'expected 1 arguments'
+        'Expected 1 argument for #each'
       );
     end
 

--- a/test/compatibility/builtins_test.rb
+++ b/test/compatibility/builtins_test.rb
@@ -516,10 +516,9 @@ describe 'builtin helpers' do
     end
 
     it 'each on implicit context' do
-      skip
       expectTemplate('{{#each}}{{text}}! {{/each}}cruel world!').toThrow(
-        handlebarsEnv.Exception,
-        'Must pass iterator to #each'
+        ArgumentError,
+        'expected 1 arguments'
       );
     end
 


### PR DESCRIPTION
- **Raise useful error when required helper arguments are missing**
- **Make argument 'name' for #execute_in_context required**
- **Improve helper arity error message**
