### PR TITLE
Improve error messages for builtin helpers

### DIFF
--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -508,7 +508,10 @@ module Haparanda
       end
     end
 
-    def handle_unless(context, value, options)
+    def handle_unless(context, *values, options)
+      raise ArgumentError, "#unless requires exactly one argument" unless values.size == 1
+
+      value = values.first
       options.fn(context) unless value
     end
 

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -497,7 +497,10 @@ module Haparanda
             "Expected #{expected} argument#{'s' if expected > 1} for #{identifier}"
     end
 
-    def handle_if(context, value, options)
+    def handle_if(context, *values, options)
+      raise ArgumentError, "#if requires exactly one argument" unless values.size == 1
+
+      value = values.first
       if value
         options.fn(context)
       else

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -515,7 +515,10 @@ module Haparanda
       options.fn(context) unless value
     end
 
-    def handle_with(_context, value, options)
+    def handle_with(_context, *values, options)
+      raise ArgumentError, "#with requires exactly one argument" unless values.size == 1
+
+      value = values.first
       if value
         options.fn(value, block_params: [value])
       else

--- a/test/compatibility/helpers_test.rb
+++ b/test/compatibility/helpers_test.rb
@@ -408,7 +408,7 @@ describe 'helpers' do
     end
 
     it 'allows multiple globals' do
-      skip
+      skip "we only allow calling this method with a name and block"
       var helpers = handlebarsEnv.helpers;
       handlebarsEnv.helpers = {};
 
@@ -430,7 +430,7 @@ describe 'helpers' do
     end
 
     it 'fails with multiple and args' do
-      skip
+      skip "we only allow calling this method with a name and block"
       shouldThrow(
         lambda {
           handlebarsEnv.registerHelper(

--- a/test/compatibility/helpers_test.rb
+++ b/test/compatibility/helpers_test.rb
@@ -714,7 +714,6 @@ describe 'helpers' do
     end
 
     it 'Builtin helpers available in knownHelpers only mode' do
-      skip
       expectTemplate('{{#unless foo}}bar{{/unless}}')
         .withCompileOptions({
           knownHelpersOnly: true,
@@ -723,7 +722,6 @@ describe 'helpers' do
     end
 
     it 'Field lookup works in knownHelpers only mode' do
-      skip
       expectTemplate('{{foo}}')
         .withCompileOptions({
           knownHelpersOnly: true,

--- a/test/compatibility/helpers_test.rb
+++ b/test/compatibility/helpers_test.rb
@@ -1030,14 +1030,12 @@ describe 'helpers' do
     end
 
     it 'unless helper - too few arguments' do
-      skip
       expectTemplate('{{#unless}}{{/unless}}').toThrow(
         /#unless requires exactly one argument/
       );
     end
 
     it 'unless helper - too many arguments' do
-      skip
       expectTemplate('{{#unless test null}}{{/unless}}').toThrow(
         /#unless requires exactly one argument/
       );

--- a/test/compatibility/helpers_test.rb
+++ b/test/compatibility/helpers_test.rb
@@ -1006,28 +1006,24 @@ describe 'helpers' do
 
   describe 'built-in helpers malformed arguments ' do
     it 'if helper - too few arguments' do
-      skip
       expectTemplate('{{#if}}{{/if}}').toThrow(
         /#if requires exactly one argument/
       );
     end
 
     it 'if helper - too many arguments, string' do
-      skip
       expectTemplate('{{#if test "string"}}{{/if}}').toThrow(
         /#if requires exactly one argument/
       );
     end
 
     it 'if helper - too many arguments, undefined' do
-      skip
       expectTemplate('{{#if test undefined}}{{/if}}').toThrow(
         /#if requires exactly one argument/
       );
     end
 
     it 'if helper - too many arguments, null' do
-      skip
       expectTemplate('{{#if test null}}{{/if}}').toThrow(
         /#if requires exactly one argument/
       );

--- a/test/compatibility/helpers_test.rb
+++ b/test/compatibility/helpers_test.rb
@@ -1042,14 +1042,12 @@ describe 'helpers' do
     end
 
     it 'with helper - too few arguments' do
-      skip
       expectTemplate('{{#with}}{{/with}}').toThrow(
         /#with requires exactly one argument/
       );
     end
 
     it 'with helper - too many arguments' do
-      skip
       expectTemplate('{{#with test "string"}}{{/with}}').toThrow(
         /#with requires exactly one argument/
       );

--- a/test/support/template_tester.rb
+++ b/test/support/template_tester.rb
@@ -64,6 +64,10 @@ class TemplateTester
   end
 
   def toThrow(error, message = nil) # rubocop:disable Naming/MethodName
+    if message.nil? && !error.is_a?(Class)
+      message = error
+      error = StandardError
+    end
     exception = _(-> { compile_and_process_template }).must_raise error
     _(exception.message).must_match message if message
   end


### PR DESCRIPTION
The builtin `#if`, `#unless` and `#with` helpers must be called with exactly one argument.

- **Skip tests for incompatible ways of calling registerHelper**
- **Enable two passing tests**
- **Raise error when #if helper is used with more than one argument**
- **Raise error when #unless helper is used with more than one argument**
- **Raise error when #with helper is used with more than one argument**
