### PR TITLE
Handle any Enumerable object in `#each` helper

### DIFF
--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -531,23 +531,17 @@ module Haparanda
 
       last = value.respond_to?(:length) ? value.length - 1 : -1
       @data.with_new_data do
-        if value.is_a? Hash
-          value.each_with_index.map do |(key, item), index|
-            @data.set_data(:key, key)
-            @data.set_data(:index, index)
-            @data.set_data(:first, index == 0)
-            @data.set_data(:last, index == last)
-            options.fn(item, block_params: [item, index])
-          end.join
-        else
-          value.each_with_index.map do |item, index|
-            @data.set_data(:key, index)
-            @data.set_data(:index, index)
-            @data.set_data(:first, index == 0)
-            @data.set_data(:last, index == last)
-            options.fn(item, block_params: [item, index])
-          end.join
+        unless value.is_a? Hash
+          value = value.each_with_index.lazy.map { |item, index| [index, item] }
         end
+        items = value.each_with_index.map do |(key, item), index|
+          @data.set_data(:key, key)
+          @data.set_data(:index, index)
+          @data.set_data(:first, index == 0)
+          @data.set_data(:last, index == last)
+          options.fn(item, block_params: [item, index])
+        end
+        items.to_a.join
       end
     end
 

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -529,7 +529,7 @@ module Haparanda
     def handle_each(_context, value, options)
       return unless value
 
-      last = value.length - 1
+      last = value.respond_to?(:length) ? value.length - 1 : -1
       @data.with_new_data do
         if value.is_a? Hash
           value.each_with_index.map do |(key, item), index|

--- a/test/compatibility/builtins_test.rb
+++ b/test/compatibility/builtins_test.rb
@@ -568,28 +568,24 @@ describe 'builtin helpers' do
 
     if true || global.Symbol&.iterator
       it 'each on iterable' do
-        skip
-        function Iterator(arr) {
-          this.arr = arr;
-          this.index = 0;
-        }
-        Iterator.prototype.next = lambda {
-          var value = this.arr[this.index];
-          var done = this.index === this.arr.length;
-          this.index += 1 if !done
-          return { value: value, done: done };
-        };
-        function Iterable(arr) {
-          this.arr = arr;
-        }
-        Iterable.prototype[global.Symbol.iterator] = lambda {
-          return new Iterator(this.arr);
-        };
-        var string = '{{#each goodbyes}}{{text}}! {{/each}}cruel {{world}}!';
+        klass = Class.new do
+          attr_accessor :arr
+
+          def initialize(arr)
+            self.arr = arr;
+          end
+
+          def each
+            arr.each { yield _1 }
+          end
+
+          include Enumerable
+        end
+        string = '{{#each goodbyes}}{{text}}! {{/each}}cruel {{world}}!';
 
         expectTemplate(string)
           .withInput({
-            goodbyes: Iterable.new([
+            goodbyes: klass.new([
               { text: 'goodbye' },
               { text: 'Goodbye' },
               { text: 'GOODBYE' },
@@ -603,7 +599,7 @@ describe 'builtin helpers' do
 
         expectTemplate(string)
           .withInput({
-            goodbyes: Iterable.new([]),
+            goodbyes: klass.new([]),
             world: 'world',
           })
           .withMessage(

--- a/test/compatibility/builtins_test.rb
+++ b/test/compatibility/builtins_test.rb
@@ -257,7 +257,7 @@ describe 'builtin helpers' do
     end
 
     it 'each with an object and @key' do
-      skip
+      skip "we don't support using #each with an arbitrary object"
       var string =
             '{{#each goodbyes}}{{@key}}. {{text}}! {{/each}}cruel {{world}}!';
 


### PR DESCRIPTION
We support enumerables but not arbitrary objects.

- **Mark use of #each with arbitrary object as not supported**
- **Handle 'iterator' (Enumerable) object in each helper**
