### PR TITLE
Add support for the 'log' helper

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,6 +90,10 @@ Style/NegatedIf:
 Style/NumericPredicate:
   Enabled: false
 
+Style/ParallelAssignment:
+  Exclude:
+    - 'test/compatibility/*'
+
 Style/QuotedSymbols:
   Exclude:
     - 'test/compatibility/*'

--- a/haparanda.gemspec
+++ b/haparanda.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.rdoc_options = ["--main", "README.md"]
   spec.extra_rdoc_files = ["README.md", "CHANGELOG.md"]
 
+  spec.add_dependency "logger", "~> 1.6"
   spec.add_dependency "racc", "~> 1.8"
   spec.add_dependency "sexp_processor", "~> 4.17"
 end

--- a/lib/haparanda/compiler.rb
+++ b/lib/haparanda/compiler.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "logger"
 require_relative "template"
 
 module Haparanda

--- a/lib/haparanda/compiler.rb
+++ b/lib/haparanda/compiler.rb
@@ -9,11 +9,12 @@ module Haparanda
       @parser = HandlebarsParser.new
       @helpers = {}
       @partials = {}
+      @log = nil
     end
 
     def compile(text, **compile_options)
       ast = template_to_ast text, **compile_options
-      Template.new(ast, @helpers, @partials, **compile_options)
+      Template.new(ast, @helpers, @partials, @log, **compile_options)
     end
 
     def register_helper(name, &definition)
@@ -31,6 +32,8 @@ module Haparanda
     def register_partial(name, content)
       @partials[name.to_s] = template_to_ast(content)
     end
+
+    attr_accessor :log
 
     private
 

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -552,6 +552,7 @@ module Haparanda
       if @log
         @log.call(level, value)
       else
+        level = Integer(level)
         logger.add(level, value)
       end
       nil

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -549,19 +549,19 @@ module Haparanda
       end
     end
 
-    def handle_log(_context, value, options)
+    def handle_log(_context, *values, options)
       level = options.hash[:level] || @data.data(:level) || 1
-      @log.call(level, value)
+      @log.call(level, *values)
       nil
     end
 
-    def default_log(level, value)
+    def default_log(level, *values)
       case level
       when String
         level = Integer(level, exception: false) || LOG_LEVELS.index(level.downcase)
       end
       level ||= Logger::UNKNOWN
-      logger.add(level, value)
+      logger.add(level, values.join(" "))
     end
 
     def logger

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -129,7 +129,7 @@ module Haparanda
         @fn = fn
         @inverse = inverse
         @name = name
-        @hash = hash
+        @hash = hash || {}
         @data = data
         @block_params = block_params
       end
@@ -549,8 +549,8 @@ module Haparanda
       end
     end
 
-    def handle_log(_context, value, _options)
-      level = @data.data(:level) || 1
+    def handle_log(_context, value, options)
+      level = options.hash[:level] || @data.data(:level) || 1
       if @log
         @log.call(level, value)
       else

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -548,7 +548,8 @@ module Haparanda
     end
 
     def handle_log(_context, value, _options)
-      @log&.call(1, value)
+      level = @data.data(:level) || 1
+      @log&.call(level, value)
       nil
     end
 

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -212,7 +212,7 @@ module Haparanda
         log: method(:handle_log)
       }.merge(helpers)
       @partials = partials
-      @log = log
+      @log = log || method(:default_log)
     end
 
     def apply(expr)
@@ -551,17 +551,17 @@ module Haparanda
 
     def handle_log(_context, value, options)
       level = options.hash[:level] || @data.data(:level) || 1
-      if @log
-        @log.call(level, value)
-      else
-        case level
-        when String
-          level = Integer(level, exception: false) || LOG_LEVELS.index(level.downcase)
-        end
-        level ||= Logger::UNKNOWN
-        logger.add(level, value)
-      end
+      @log.call(level, value)
       nil
+    end
+
+    def default_log(level, value)
+      case level
+      when String
+        level = Integer(level, exception: false) || LOG_LEVELS.index(level.downcase)
+      end
+      level ||= Logger::UNKNOWN
+      logger.add(level, value)
     end
 
     def logger

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -549,8 +549,16 @@ module Haparanda
 
     def handle_log(_context, value, _options)
       level = @data.data(:level) || 1
-      @log&.call(level, value)
+      if @log
+        @log.call(level, value)
+      else
+        logger.add(level, value)
+      end
       nil
+    end
+
+    def logger
+      @logger ||= Logger.new($stderr)
     end
 
     def raise_helper_missing(name)

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -194,7 +194,7 @@ module Haparanda
       end
     end
 
-    def initialize(input, helpers: {}, partials: {}, data: {})
+    def initialize(input, helpers: {}, partials: {}, data: {}, log: nil)
       super()
 
       self.require_empty = false
@@ -208,9 +208,11 @@ module Haparanda
         if: method(:handle_if),
         unless: method(:handle_unless),
         with: method(:handle_with),
-        each: method(:handle_each)
+        each: method(:handle_each),
+        log: method(:handle_log)
       }.merge(helpers)
       @partials = partials
+      @log = log
     end
 
     def apply(expr)
@@ -543,6 +545,11 @@ module Haparanda
         end
         items.to_a.join
       end
+    end
+
+    def handle_log(_context, value, _options)
+      @log&.call(1, value)
+      nil
     end
 
     def raise_helper_missing(name)

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -332,6 +332,8 @@ module Haparanda
       s(:result, result)
     end
 
+    LOG_LEVELS = %w[debug info warn error].freeze
+
     private
 
     # rubocop:todo Metrics/PerceivedComplexity
@@ -552,7 +554,11 @@ module Haparanda
       if @log
         @log.call(level, value)
       else
-        level = Integer(level)
+        case level
+        when String
+          level = Integer(level, exception: false) || LOG_LEVELS.index(level.downcase)
+        end
+        level ||= Logger::UNKNOWN
         logger.add(level, value)
       end
       nil

--- a/lib/haparanda/template.rb
+++ b/lib/haparanda/template.rb
@@ -3,10 +3,11 @@
 module Haparanda
   # Callable representation of a handlebars template
   class Template
-    def initialize(expr, helpers, partials, **compile_options)
+    def initialize(expr, helpers, partials, log, **compile_options)
       @expr = expr
       @helpers = helpers
       @partials = partials
+      @log = log
       @compile_options = compile_options
     end
 
@@ -21,6 +22,7 @@ module Haparanda
       processor = HandlebarsProcessor.new(input,
                                           helpers: all_helpers,
                                           partials: @partials,
+                                          log: @log,
                                           **runtime_options)
       processor.apply(@expr)
     end

--- a/test/compatibility/builtins_test.rb
+++ b/test/compatibility/builtins_test.rb
@@ -681,8 +681,8 @@ describe 'builtin helpers' do
     end
 
     it 'should handle missing logger' do
-      skip
-      var called = false;
+      skip "no ruby equivalent of this case exists really"
+      called = false;
 
       console.error = undefined;
       # console.log = lambda { |log|
@@ -700,29 +700,33 @@ describe 'builtin helpers' do
     end
 
     it 'should handle string log levels' do
-      skip
-      var called;
-
-      # console.error = lambda { |log|
-      #   equals('whee', log);
-      #   called = true;
-      # };
+      io = StringIO.new(String.new, "w+")
+      $stderr = io
 
       expectTemplate('{{log blah}}')
         .withInput({ blah: 'whee' })
         .withRuntimeOptions({ data: { level: 'error' } })
         .withCompileOptions({ data: true })
         .toCompileTo('');
-      equals(true, called);
 
-      called = false;
+      $stderr = @stderr
+      io.rewind
+      message = io.read
+      _(message).must_match(/ERROR -- : whee/)
+
+      io = StringIO.new(String.new, "w+")
+      $stderr = io
 
       expectTemplate('{{log blah}}')
         .withInput({ blah: 'whee' })
         .withRuntimeOptions({ data: { level: 'ERROR' } })
         .withCompileOptions({ data: true })
         .toCompileTo('');
-      equals(true, called);
+
+      $stderr = @stderr
+      io.rewind
+      message = io.read
+      _(message).must_match(/ERROR -- : whee/)
     end
 
     it 'should handle hash log levels' do

--- a/test/compatibility/builtins_test.rb
+++ b/test/compatibility/builtins_test.rb
@@ -644,12 +644,11 @@ describe 'builtin helpers' do
     end
 
     it 'should call logger at data level' do
-      skip
-      # var levelArg, logArg;
-      # handlebarsEnv.log = lambda { |level, arg|
-      #   levelArg = level;
-      #   logArg = arg;
-      # };
+      levelArg, logArg = nil, nil
+      handlebarsEnv.log = lambda { |level, arg|
+        levelArg = level;
+        logArg = arg;
+      };
 
       expectTemplate('{{log blah}}')
         .withInput({ blah: 'whee' })

--- a/test/compatibility/builtins_test.rb
+++ b/test/compatibility/builtins_test.rb
@@ -665,21 +665,19 @@ describe 'builtin helpers' do
     end
 
     it 'should log at data level' do
-      skip
-      var called;
-
-      # console.error = lambda { |log|
-      #   equals('whee', log);
-      #   called = true;
-      #   console.error = $error;
-      # };
+      io = StringIO.new(String.new, "w+")
+      $stderr = io
 
       expectTemplate('{{log blah}}')
         .withInput({ blah: 'whee' })
         .withRuntimeOptions({ data: { level: '03' } })
         .withCompileOptions({ data: true })
         .toCompileTo('');
-      equals(true, called);
+
+      $stderr = @stderr
+      io.rewind
+      message = io.read
+      _(message).must_match(/ERROR -- : whee/)
     end
 
     it 'should handle missing logger' do

--- a/test/compatibility/builtins_test.rb
+++ b/test/compatibility/builtins_test.rb
@@ -758,37 +758,30 @@ describe 'builtin helpers' do
     end
 
     it 'should pass multiple log arguments' do
-      skip
-      var called;
-
-      # console.info = console.log = lambda { |log1, log2, log3|
-      #   equals('whee', log1);
-      #   equals('foo', log2);
-      #   equals(1, log3);
-      #   called = true;
-      #   console.log = $log;
-      # };
+      io = StringIO.new(String.new, "w+")
+      $stderr = io
 
       expectTemplate('{{log blah "foo" 1}}')
         .withInput({ blah: 'whee' })
         .toCompileTo('');
-      equals(true, called);
+
+      $stderr = @stderr
+      io.rewind
+      message = io.read
+      _(message).must_match(/INFO -- : whee foo 1/)
     end
 
     it 'should pass zero log arguments' do
-      skip
-      var called;
-
-      # console.info = console.log = lambda {
-      #   expect(arguments.length).to.equal(0);
-      #   called = true;
-      #   console.log = $log;
-      # };
+      io = StringIO.new(String.new, "w+")
+      $stderr = io
 
       expectTemplate('{{log}}').withInput({ blah: 'whee' }).toCompileTo('');
-      expect(called).to.be.true;
+
+      $stderr = @stderr
+      io.rewind
+      message = io.read
+      _(message).must_match(/INFO -- : $/)
     end
-    # /* eslint-enable no-console */
   end
 
   describe '#lookup' do

--- a/test/compatibility/builtins_test.rb
+++ b/test/compatibility/builtins_test.rb
@@ -730,37 +730,31 @@ describe 'builtin helpers' do
     end
 
     it 'should handle hash log levels' do
-      skip
-      var called;
-
-      # console.error = lambda { |log|
-      #   equals('whee', log);
-      #   called = true;
-      # };
+      io = StringIO.new(String.new, "w+")
+      $stderr = io
 
       expectTemplate('{{log blah level="error"}}')
         .withInput({ blah: 'whee' })
         .toCompileTo('');
-      equals(true, called);
+
+      $stderr = @stderr
+      io.rewind
+      message = io.read
+      _(message).must_match(/ERROR -- : whee/)
     end
 
     it 'should handle hash log levels' do
-      skip
-      var called = false;
-
-      # console.info =
-      #   console.log =
-      #   console.error =
-      #   console.debug =
-      #     lambda {
-      #       called = true;
-      #       console.info = console.log = console.error = console.debug = $log;
-      #     };
+      io = StringIO.new(String.new, "w+")
+      $stderr = io
 
       expectTemplate('{{log blah level="debug"}}')
         .withInput({ blah: 'whee' })
         .toCompileTo('');
-      equals(false, called);
+
+      $stderr = @stderr
+      io.rewind
+      message = io.read
+      _(message).must_match(/DEBUG -- : whee/)
     end
 
     it 'should pass multiple log arguments' do

--- a/test/compatibility/builtins_test.rb
+++ b/test/compatibility/builtins_test.rb
@@ -629,12 +629,11 @@ describe 'builtin helpers' do
     end
 
     it 'should call logger at default level' do
-      skip
-      # var levelArg, logArg;
-      # handlebarsEnv.log = lambda { |level, arg|
-      #   levelArg = level;
-      #   logArg = arg;
-      # };
+      levelArg, logArg = nil, nil
+      handlebarsEnv.log = lambda { |level, arg|
+        levelArg = level;
+        logArg = arg;
+      };
 
       expectTemplate('{{log blah}}')
         .withInput({ blah: 'whee' })

--- a/test/compatibility/builtins_test.rb
+++ b/test/compatibility/builtins_test.rb
@@ -611,21 +611,12 @@ describe 'builtin helpers' do
   end
 
   describe '#log' do
-    # /* eslint-disable no-console */
-    # if (typeof console === 'undefined')
-    #   return;
-    # end
-
-    # var $log, $info, $error;
     before do
-      # $log = console.log;
-      # $info = console.info;
-      # $error = console.error;
+      @stderr = $stderr
     end
+
     after do
-      # console.log = $log;
-      # console.info = $info;
-      # console.error = $error;
+      $stderr = @stderr
     end
 
     it 'should call logger at default level' do
@@ -660,26 +651,17 @@ describe 'builtin helpers' do
     end
 
     it 'should output to info' do
-      skip
-      var called;
-
-      # console.info = lambda { |info|
-      #   equals('whee', info);
-      #   called = true;
-      #   console.info = $info;
-      #   console.log = $log;
-      # };
-      # console.log = lambda { |log|
-      #   equals('whee', log);
-      #   called = true;
-      #   console.info = $info;
-      #   console.log = $log;
-      # };
+      io = StringIO.new(String.new, "w+")
+      $stderr = io
 
       expectTemplate('{{log blah}}')
         .withInput({ blah: 'whee' })
         .toCompileTo('');
-      equals(true, called);
+
+      $stderr = @stderr
+      io.rewind
+      message = io.read
+      _(message).must_match(/INFO -- : whee/)
     end
 
     it 'should log at data level' do

--- a/test/support/compatibility_test_helpers.rb
+++ b/test/support/compatibility_test_helpers.rb
@@ -5,12 +5,12 @@ require_relative "template_tester"
 # Helper methods to make compatibility tests most similar to original
 # handlebars-parser and handlebars.js specs.
 module CompatibilityTestHelpers
-  def equals(act, exp)
+  def equals(act, exp, message = nil)
     exp = exp.gsub('\n', "\n") if exp.is_a? String
     if exp.nil?
-      _(act).must_be_nil
+      _(act).must_be_nil message
     else
-      _(act).must_equal exp
+      _(act).must_equal exp, message
     end
   end
 


### PR DESCRIPTION
This implements the built-in handlbars 'log' helper.

- **Implement basic log helper**
- **Fetch log level from data**
- **Log to Logger object by default**
- **Set log level from data when logging to default logger**
- **Allow setting the log level for the default logger using a level name**
- **Allow setting the log level using a hash argument**
- **Add logger dependency in anticipation of Ruby 3.5**
- **Call default and custom log the same way**
- **Let log helper take any number of arguments**
