### PR TITLE
Look up missing values in the parent context

### DIFF
--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -40,8 +40,11 @@ module Haparanda
       end
 
       def dig(*keys)
+        return @parent&.dig(*keys[1..]) if keys.first == :".."
+
         result = dig_value(@value, keys)
-        result = @parent&.dig(*keys) if result.nil?
+        return @parent&.dig(*keys) if result.nil?
+
         result
       end
 
@@ -73,14 +76,7 @@ module Haparanda
       end
 
       def dig(*keys)
-        index = -1
-        while keys.first == :".."
-          keys.shift
-          index -= 1
-        end
-
-        value = @stack[index]
-        value&.dig(*keys)
+        top&.dig(*keys)
       end
 
       def [](key)

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -34,12 +34,15 @@ module Haparanda
     class Input
       include ValueDigger
 
-      def initialize(value)
+      def initialize(value, parent = nil)
         @value = value
+        @parent = parent
       end
 
       def dig(*keys)
-        dig_value(@value, keys)
+        result = dig_value(@value, keys)
+        result = @parent&.dig(*keys) if result.nil?
+        result
       end
 
       def [](key)
@@ -86,10 +89,10 @@ module Haparanda
 
       def with_new_context(value, &block)
         # TODO: See if this can be removed
-        if self == value || value == @stack.last
+        if self == value || value == top
           block.call
         else
-          @stack.push Input.new(value)
+          @stack.push Input.new(value, top)
           result = block.call
           @stack.pop
           result

--- a/test/integration/blocks_test.rb
+++ b/test/integration/blocks_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe "blocks" do
+  let(:compiler) { Haparanda::Compiler.new }
+
+  describe "context nesting" do
+    it "allows lookup in the parent context" do
+      result = compiler.compile("{{#foo}}{{bar}}{{baz}}{{/foo}}")
+                       .call({ foo: { bar: "bar" }, baz: "baz" })
+
+      _(result).must_equal "barbaz"
+    end
+  end
+end


### PR DESCRIPTION
This behaviour is needed for compatibility with Mustache.

- **Fall back to the parent context if a value cannot be found**
- **Move explicit parent value lookup to Input class**
