### PR TITLE
Raise informative error when partial has too many arguments

### DIFF
--- a/lib/haparanda/content_combiner.rb
+++ b/lib/haparanda/content_combiner.rb
@@ -20,6 +20,11 @@ module Haparanda
       s(:statements, *statements)
     end
 
+    def process(expr)
+      line = expr.line
+      super.tap { _1.line(line) if line }
+    end
+
     private
 
     def combine_contents(statements)

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -307,14 +307,7 @@ module Haparanda
       hash = extract_hash hash
       with_block_params(hash.keys, hash.values) do
         if value || @explicit_partial_context
-          program = ->(item) { @input_stack.with_isolated_context(item) { apply(partial) } }
-
-          result = case value
-                   when Array
-                     value.map { |item| program.call item }.join
-                   else
-                     program.call value
-                   end
+          result = @input_stack.with_isolated_context(value) { apply(partial) }
           s(:result, result)
         else
           process(partial)

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -295,10 +295,14 @@ module Haparanda
     def process_partial(expr)
       _, name, context, hash, = expr
 
-      partial = lookup_partial(name)
+      values = process(context)[1]
+      if values.length > 1
+        raise "Unsupported number of partial arguments: #{values.length} - #{expr.line}"
+      end
 
-      values = process(context)
-      value = values[1].first
+      value = values.first
+
+      partial = lookup_partial(name)
 
       hash = extract_hash hash
       with_block_params(hash.keys, hash.values) do

--- a/lib/haparanda/whitespace_handler.rb
+++ b/lib/haparanda/whitespace_handler.rb
@@ -13,6 +13,11 @@ module Haparanda
       self.require_empty = false
     end
 
+    def process(expr)
+      line = expr&.line
+      super.tap { _1.line(line) if line }
+    end
+
     def process_root(expr)
       _, statements = expr
 

--- a/test/compatibility/partials_test.rb
+++ b/test/compatibility/partials_test.rb
@@ -109,8 +109,6 @@ describe 'partials' do
       .withCompileOptions({ explicitPartialContext: true })
       .toCompileTo('Dudes:  ()  () ');
 
-    skip
-
     expectTemplate('Dudes: {{#dudes}}{{>dude name="foo"}}{{/dudes}}')
       .withInput(hash)
       .withPartial('dude', partial)

--- a/test/compatibility/partials_test.rb
+++ b/test/compatibility/partials_test.rb
@@ -129,10 +129,9 @@ describe 'partials' do
   end
 
   it 'partials with duplicate parameters' do
-    skip
     expectTemplate('Dudes: {{>dude dudes foo bar=baz}}').toThrow(
-      Error,
-      'Unsupported number of partial arguments: 2 - 1:7'
+      StandardError,
+      'Unsupported number of partial arguments: 2 - 1'
     );
   end
 


### PR DESCRIPTION
This implements the informative message to be raised when a partial is called with more than one (positional) argument. To allow the line number to be shown, the WhitespaceHandler and ContentCombiner classes are changed so they keep the expressions' line numbering intact.

This pull request contains quite a bit of refactoring to reduce the complexity of the `#process_partial` method.

- **Enable spec that passes now that named partial parameters are supported**
- **Unify handling of hash arguments in HandlebarsProcessor**
- **Raise informative error when partial has too many arguments**
- **Simplify implementation of partial calling**
