### PR TITLE
Support partial blocks

### DIFF
--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -329,6 +329,15 @@ module Haparanda
       end
     end
 
+    def process_partial_block(expr)
+      _, _name, context, _hash, partial = expr
+
+      values = process(context)[1]
+      value = values.first
+      result = @input_stack.with_new_context(value) { apply(partial) }
+      s(:result, result)
+    end
+
     def process_statements(expr)
       results = expr.sexp_body.map { process(_1)[1] }
       s(:result, results.join)

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -330,10 +330,12 @@ module Haparanda
     end
 
     def process_partial_block(expr)
-      _, _name, context, _hash, partial = expr
+      _, name, context, _hash, partial = expr
 
       values = process(context)[1]
       value = values.first
+      partial = lookup_partial(name, partial)
+
       result = @input_stack.with_new_context(value) { apply(partial) }
       s(:result, result)
     end
@@ -520,12 +522,12 @@ module Haparanda
       return value, name
     end
 
-    def lookup_partial(expr)
+    def lookup_partial(expr, fallback = nil)
       path = process(expr)
       _data, name, _elements = path_segments(path)
 
       @partials.fetch(name) do
-        raise KeyError, "The partial \"#{name}\" could not be found"
+        fallback or raise KeyError, "The partial \"#{name}\" could not be found"
       end
     end
 

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -321,8 +321,7 @@ module Haparanda
       hash = extract_hash hash
       with_block_params(hash.keys, hash.values) do
         if value || @explicit_partial_context
-          result = @input_stack.with_isolated_context(value) { apply(partial) }
-          s(:result, result)
+          @input_stack.with_isolated_context(value) { process(partial) }
         else
           process(partial)
         end
@@ -338,8 +337,7 @@ module Haparanda
 
       @data.with_new_data do
         @data.set_data(:"partial-block", partial_block)
-        result = @input_stack.with_new_context(value) { apply(partial) }
-        s(:result, result)
+        @input_stack.with_new_context(value) { process(partial) }
       end
     end
 

--- a/test/compatibility/partials_test.rb
+++ b/test/compatibility/partials_test.rb
@@ -333,7 +333,6 @@ describe 'partials' do
     end
 
     it 'should propagate block parameters to default block' do
-      skip
       expectTemplate(
         '{{#with context as |me|}}{{#> dude}}{{me.value}}{{/dude}}{{/with}}'
       )

--- a/test/compatibility/partials_test.rb
+++ b/test/compatibility/partials_test.rb
@@ -419,7 +419,6 @@ describe 'partials' do
     end
 
     it 'should render nested partial blocks' do
-      skip
       expectTemplate('<template>{{#> outer}}{{value}}{{/outer}}</template>')
         .withInput({ value: 'success' })
         .withPartials({
@@ -433,7 +432,6 @@ describe 'partials' do
     end
 
     it 'should render nested partial blocks at different nesting levels' do
-      skip
       expectTemplate('<template>{{#> outer}}{{value}}{{/outer}}</template>')
         .withInput({ value: 'success' })
         .withPartials({
@@ -447,7 +445,6 @@ describe 'partials' do
     end
 
     it 'should render nested partial blocks at different nesting levels (twice)' do
-      skip
       expectTemplate('<template>{{#> outer}}{{value}}{{/outer}}</template>')
         .withInput({ value: 'success' })
         .withPartials({
@@ -461,7 +458,6 @@ describe 'partials' do
     end
 
     it 'should render nested partial blocks (twice at each level)' do
-      skip
       expectTemplate('<template>{{#> outer}}{{value}}{{/outer}}</template>')
         .withInput({ value: 'success' })
         .withPartials({

--- a/test/compatibility/partials_test.rb
+++ b/test/compatibility/partials_test.rb
@@ -353,14 +353,12 @@ describe 'partials' do
     end
 
     it 'should be able to render the partial-block twice' do
-      skip
       expectTemplate('{{#> dude}}success{{/dude}}')
         .withPartials({ dude: '{{> @partial-block }} {{> @partial-block }}' })
         .toCompileTo('success success');
     end
 
     it 'should render block from partial with context' do
-      skip
       expectTemplate('{{#> dude}}{{value}}{{/dude}}')
         .withInput({ context: { value: 'success' } })
         .withPartials({
@@ -370,7 +368,6 @@ describe 'partials' do
     end
 
     it 'should be able to access the @data frame from a partial-block' do
-      skip
       expectTemplate('{{#> dude}}in-block: {{@root/value}}{{/dude}}')
         .withInput({ value: 'success' })
         .withPartials({
@@ -380,7 +377,6 @@ describe 'partials' do
     end
 
     it 'should allow the #each-helper to be used along with partial-blocks' do
-      skip
       expectTemplate(
         '<template>{{#> list value}}value = {{.}}{{/list}}</template>'
       )
@@ -396,7 +392,6 @@ describe 'partials' do
     end
 
     it 'should render block from partial with context (twice)' do
-      skip
       expectTemplate('{{#> dude}}{{value}}{{/dude}}')
         .withInput({ context: { value: 'success' } })
         .withPartials({
@@ -406,7 +401,6 @@ describe 'partials' do
     end
 
     it 'should render block from partial with context' do
-      skip
       expectTemplate('{{#> dude}}{{../context/value}}{{/dude}}')
         .withInput({ context: { value: 'success' } })
         .withPartials({
@@ -416,7 +410,6 @@ describe 'partials' do
     end
 
     it 'should render block from partial with block params' do
-      skip
       expectTemplate(
         '{{#with context as |me|}}{{#> dude}}{{me.value}}{{/dude}}{{/with}}'
       )

--- a/test/compatibility/partials_test.rb
+++ b/test/compatibility/partials_test.rb
@@ -341,7 +341,6 @@ describe 'partials' do
     end
 
     it 'should not use partial block if partial exists' do
-      skip
       expectTemplate('{{#> dude}}fail{{/dude}}')
         .withPartials({ dude: 'success' })
         .toCompileTo('success');

--- a/test/compatibility/partials_test.rb
+++ b/test/compatibility/partials_test.rb
@@ -323,12 +323,10 @@ describe 'partials' do
 
   describe 'partial blocks' do
     it 'should render partial block as default' do
-      skip
       expectTemplate('{{#> dude}}success{{/dude}}').toCompileTo('success');
     end
 
     it 'should execute default block with proper context' do
-      skip
       expectTemplate('{{#> dude context}}{{value}}{{/dude}}')
         .withInput({ context: { value: 'success' } })
         .toCompileTo('success');

--- a/test/compatibility/partials_test.rb
+++ b/test/compatibility/partials_test.rb
@@ -347,7 +347,6 @@ describe 'partials' do
     end
 
     it 'should render block from partial' do
-      skip
       expectTemplate('{{#> dude}}success{{/dude}}')
         .withPartials({ dude: '{{> @partial-block }}' })
         .toCompileTo('success');


### PR DESCRIPTION
- **Implement basic handling of partial blocks**
- **Enable spec showing that block parameters are propagated to partial block**
- **Prioritize named external partial over partial block**
- **Pass partial block to external partial via @partial-block data**
- **Enable several passing specs**
- **Simplify application of partial**
- **Turn partials into closures with a value parameter before processing them**
- **Make nested partial blocks work with @partial-block data**
