### PR TITLE
Support inline definition of partials

### DIFF
--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -370,6 +370,16 @@ module Haparanda
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
 
+    def process_directive_block(expr)
+      _, name, params, _hash, program, _inverse_chain, = expr
+      name = name.dig(2, 1)
+      raise "Only 'inline' is supported, got #{name}" unless name == "inline"
+
+      args = process(params)[1]
+      partial_name = args[0]
+      @partials[partial_name] = program
+    end
+
     def process_statements(expr)
       results = expr.sexp_body.map { process(_1)[1] }
       s(:result, results.join)

--- a/lib/haparanda/handlebars_processor.rb
+++ b/lib/haparanda/handlebars_processor.rb
@@ -353,6 +353,10 @@ module Haparanda
 
         @data.set_data(:"partial-block", partial_block_wrapper)
 
+        partial_block.sexp_body.each do |sexp|
+          process(sexp) if sexp.sexp_type == :directive_block
+        end
+
         partial = lookup_partial(name, raise_error: false)
         partial ||= partial_block_wrapper
         partial_f = if partial.is_a?(Sexp)

--- a/lib/haparanda/template.rb
+++ b/lib/haparanda/template.rb
@@ -15,7 +15,7 @@ module Haparanda
 
     def call(input, helpers: {}, partials: {}, data: {})
       all_helpers = @helpers.merge(helpers)
-      partials.transform_values! { Parser.new(**@compile_options).parse(_1) }
+      partials.transform_values! { parse_partial(_1) }
       all_partials = @partials.merge(partials)
       if @compile_options[:known_helpers_only]
         keys = @compile_options[:known_helpers]&.keys || []
@@ -32,6 +32,14 @@ module Haparanda
                                 data: data,
                                 explicit_partial_context: explicit_partial_context)
       processor.apply(@expr)
+    end
+
+    private
+
+    def parse_partial(partial)
+      return partial if partial.respond_to? :call
+
+      Parser.new(**@compile_options).parse(partial)
     end
   end
 end

--- a/test/compatibility/partials_test.rb
+++ b/test/compatibility/partials_test.rb
@@ -508,21 +508,18 @@ describe 'partials' do
     end
 
     it 'should override template partials' do
-      skip
       expectTemplate(
         '{{#*inline "myPartial"}}fail{{/inline}}{{#with .}}{{#*inline "myPartial"}}success{{/inline}}{{> myPartial}}{{/with}}'
       ).toCompileTo('success');
     end
 
     it 'should override partials down the entire stack' do
-      skip
       expectTemplate(
         '{{#with .}}{{#*inline "myPartial"}}success{{/inline}}{{#with .}}{{#with .}}{{> myPartial}}{{/with}}{{/with}}{{/with}}'
       ).toCompileTo('success');
     end
 
     it 'should define inline partials for partial call' do
-      skip
       expectTemplate('{{#*inline "myPartial"}}success{{/inline}}{{> dude}}')
         .withPartials({ dude: '{{> myPartial }}' })
         .toCompileTo('success');
@@ -538,7 +535,6 @@ describe 'partials' do
     end
 
     it 'should render nested inline partials' do
-      skip
       expectTemplate(
         '{{#*inline "outer"}}{{#>inner}}<outer-block>{{>@partial-block}}</outer-block>{{/inner}}{{/inline}}' +
           '{{#*inline "inner"}}<inner>{{>@partial-block}}</inner>{{/inline}}' +
@@ -549,7 +545,6 @@ describe 'partials' do
     end
 
     it 'should render nested inline partials with partial-blocks on different nesting levels' do
-      skip
       expectTemplate(
         '{{#*inline "outer"}}{{#>inner}}<outer-block>{{>@partial-block}}</outer-block>{{/inner}}{{>@partial-block}}{{/inline}}' +
           '{{#*inline "inner"}}<inner>{{>@partial-block}}</inner>{{/inline}}' +
@@ -562,7 +557,6 @@ describe 'partials' do
     end
 
     it 'should render nested inline partials (twice at each level)' do
-      skip
       expectTemplate(
         '{{#*inline "outer"}}{{#>inner}}<outer-block>{{>@partial-block}} {{>@partial-block}}</outer-block>{{/inner}}{{/inline}}' +
           '{{#*inline "inner"}}<inner>{{>@partial-block}}{{>@partial-block}}</inner>{{/inline}}' +

--- a/test/compatibility/partials_test.rb
+++ b/test/compatibility/partials_test.rb
@@ -480,21 +480,19 @@ describe 'partials' do
     end
 
     it 'should overwrite multiple partials in the same template' do
-      skip
       expectTemplate(
         '{{#*inline "myPartial"}}fail{{/inline}}{{#*inline "myPartial"}}success{{/inline}}{{> myPartial}}'
       ).toCompileTo('success');
     end
 
     it 'should define inline partials for block' do
-      skip
       expectTemplate(
         '{{#with .}}{{#*inline "myPartial"}}success{{/inline}}{{> myPartial}}{{/with}}'
       ).toCompileTo('success');
 
       expectTemplate(
         '{{#with .}}{{#*inline "myPartial"}}success{{/inline}}{{/with}}{{> myPartial}}'
-      ).toThrow(Error, /"myPartial" could not/);
+      ).toThrow(StandardError, /"myPartial" could not/);
     end
 
     it 'should override global partials' do

--- a/test/compatibility/partials_test.rb
+++ b/test/compatibility/partials_test.rb
@@ -496,7 +496,6 @@ describe 'partials' do
     end
 
     it 'should override global partials' do
-      skip
       expectTemplate(
         '{{#*inline "myPartial"}}success{{/inline}}{{> myPartial}}'
       )

--- a/test/compatibility/partials_test.rb
+++ b/test/compatibility/partials_test.rb
@@ -474,7 +474,6 @@ describe 'partials' do
 
   describe 'inline partials' do
     it 'should define inline partials for template' do
-      skip
       expectTemplate(
         '{{#*inline "myPartial"}}success{{/inline}}{{> myPartial}}'
       ).toCompileTo('success');

--- a/test/compatibility/partials_test.rb
+++ b/test/compatibility/partials_test.rb
@@ -526,7 +526,6 @@ describe 'partials' do
     end
 
     it 'should define inline partials in partial block call' do
-      skip
       expectTemplate(
         '{{#> dude}}{{#*inline "myPartial"}}success{{/inline}}{{/dude}}'
       )

--- a/test/integration/partials_test.rb
+++ b/test/integration/partials_test.rb
@@ -14,4 +14,16 @@ describe "partials" do
       _(result).must_equal "bar"
     end
   end
+
+  describe "inline partial loopup" do
+    it "finds inline partials as top level elements inside partial block calls" do
+      compiler.register_partial("dude", "{{> myPartial }}")
+      result =
+        compiler
+        .compile(
+          '{{#> dude}}foo{{qux}}{{#*inline "myPartial"}}bar{{/inline}}{{baz}}{{/dude}}'
+        ).call({})
+      _(result).must_equal "bar"
+    end
+  end
 end


### PR DESCRIPTION
- **Add simple implementation of 'inline' directive**
- **Make inline partial definitions only affect the current block**
- **Allow partials to be defined as callables at runtime**
- **Enable several passing tests**
- **Extract inline partials from partial block contents**
