### PR TITLE
Split whitespace handler into two parts

### DIFF
--- a/lib/haparanda/parser.rb
+++ b/lib/haparanda/parser.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 require_relative "content_combiner"
-require_relative "whitespace_handler"
+require_relative "standalone_whitespace_handler"
+require_relative "whitespace_stripper"
 
 module Haparanda
   # Parse a handlebars string to an AST in the form needed to apply input to it:
@@ -16,7 +17,8 @@ module Haparanda
     def parse(text)
       expr = HandlebarsParser.new.parse(text)
       expr = ContentCombiner.new.process(expr)
-      WhitespaceHandler.new(ignore_standalone: @ignore_standalone).process(expr)
+      expr = StandaloneWhitespaceHandler.new.process(expr) unless @ignore_standalone
+      WhitespaceStripper.new.process(expr)
     end
   end
 end

--- a/lib/haparanda/standalone_whitespace_handler.rb
+++ b/lib/haparanda/standalone_whitespace_handler.rb
@@ -4,11 +4,9 @@ require "sexp_processor"
 
 module Haparanda
   # Process the handlebars AST just to do the whitespace stripping.
-  class WhitespaceHandler < SexpProcessor # rubocop:disable Metrics/ClassLength
-    def initialize(ignore_standalone: false)
-      super()
-
-      @ignore_standalone = ignore_standalone
+  class StandaloneWhitespaceHandler < SexpProcessor
+    def initialize
+      super
 
       self.require_empty = false
     end
@@ -34,41 +32,15 @@ module Haparanda
       _, name, params, hash, program, inverse_chain, open_strip, close_strip = expr
 
       program = process(program)
-      if inverse_chain && inverse_chain.last.nil?
-        body = inverse_chain.sexp_body
-        body[-1] = close_strip
-        inverse_chain.sexp_body = body
-      end
       inverse_chain = process(inverse_chain)
 
       statements = program&.at(2)&.sexp_body
-      if statements
-        strip_initial_whitespace(statements.first, open_strip)
-        strip_final_whitespace(statements.last, close_strip)
-      end
 
       if statements && inverse_chain
         strip_standalone_whitespace(statements.last, first_item(inverse_chain))
       end
 
       s(:block, name, params, hash, program, inverse_chain, open_strip, close_strip)
-    end
-
-    def process_inverse(expr)
-      _, block_params, statements, open_strip, close_strip = expr
-
-      block_params = process(block_params)
-      statements = process(statements)
-
-      case statements.sexp_type
-      when :statements
-        items = statements.sexp_body
-        strip_initial_whitespace(items.first, open_strip)
-        strip_final_whitespace(items.last, close_strip)
-      end
-      # TODO: Handle :block sexp_type
-
-      s(:inverse, block_params, statements, open_strip, close_strip)
     end
 
     def process_statements(expr)
@@ -89,15 +61,12 @@ module Haparanda
         next if partial.sexp_type != :partial
         next unless preceding_whitespace? prev
 
-        strip_initial_whitespace(item, s(:strip, true, true))
+        strip_initial_whitespace(item)
       end
     end
 
     def strip_pairwise_sibling_whitespace(statements)
       statements.each_cons(2) do |prev, item|
-        strip_final_whitespace(prev, open_strip_for(item)) if item.sexp_type != :content
-        strip_initial_whitespace(item, close_strip_for(prev)) if prev.sexp_type != :content
-
         strip_standalone_whitespace(prev, first_item(item)) if item.sexp_type == :block
         strip_standalone_whitespace(last_item(prev), item) if prev.sexp_type == :block
       end
@@ -133,12 +102,8 @@ module Haparanda
       end
     end
 
-    def strip_initial_whitespace(item, strip)
-      item[1] = item[1].sub(/^\s*/, "") if item.sexp_type == :content && strip[2]
-    end
-
-    def strip_final_whitespace(item, strip)
-      item[1] = item[1].sub(/\s*$/, "") if item.sexp_type == :content && strip&.at(1)
+    def strip_initial_whitespace(item)
+      item[1] = item[1].sub(/^\s*/, "") if item.sexp_type == :content
     end
 
     def strip_standalone_whitespace(before, after)
@@ -159,29 +124,12 @@ module Haparanda
 
     # Strip trailing whitespace before but leave the \n
     def clear_preceding_whitespace(before)
-      return if @ignore_standalone
-
       before[1] = before[1].sub(/\n[ \t]+$/, "\n")
     end
 
     # Strip leading whitespace after including the \n
     def clear_following_whitespace(after)
-      return if @ignore_standalone
-
       after[1] = after[1].sub(/^[ \t]*\n/, "")
-    end
-
-    def open_strip_for(item)
-      case item.sexp_type
-      when :block
-        item.at(-2)
-      else
-        item.last
-      end
-    end
-
-    def close_strip_for(item)
-      item.last
     end
   end
 end

--- a/lib/haparanda/whitespace_stripper.rb
+++ b/lib/haparanda/whitespace_stripper.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "sexp_processor"
+
+module Haparanda
+  # Process the handlebars AST just to do the whitespace stripping.
+  class WhitespaceStripper < SexpProcessor
+    def initialize
+      super
+
+      self.require_empty = false
+    end
+
+    def process(expr)
+      line = expr&.line
+      super.tap { _1.line(line) if line }
+    end
+
+    def process_root(expr)
+      _, statements = expr
+
+      statements = process(statements)
+      s(:root, statements)
+    end
+
+    def process_block(expr)
+      _, name, params, hash, program, inverse_chain, open_strip, close_strip = expr
+
+      program = process(program)
+      if inverse_chain && inverse_chain.last.nil?
+        body = inverse_chain.sexp_body
+        body[-1] = close_strip
+        inverse_chain.sexp_body = body
+      end
+      inverse_chain = process(inverse_chain)
+
+      statements = program&.at(2)&.sexp_body
+      if statements
+        strip_initial_whitespace(statements.first, open_strip)
+        strip_final_whitespace(statements.last, close_strip)
+      end
+
+      s(:block, name, params, hash, program, inverse_chain, open_strip, close_strip)
+    end
+
+    def process_inverse(expr)
+      _, block_params, statements, open_strip, close_strip = expr
+
+      block_params = process(block_params)
+      statements = process(statements)
+
+      case statements.sexp_type
+      when :statements
+        items = statements.sexp_body
+        strip_initial_whitespace(items.first, open_strip)
+        strip_final_whitespace(items.last, close_strip)
+      end
+      # TODO: Handle :block sexp_type
+
+      s(:inverse, block_params, statements, open_strip, close_strip)
+    end
+
+    def process_statements(expr)
+      statements = expr.sexp_body
+
+      strip_pairwise_sibling_whitespace(statements)
+
+      statements = statements.map { process(_1) }
+
+      s(:statements, *statements)
+    end
+
+    private
+
+    def strip_pairwise_sibling_whitespace(statements)
+      statements.each_cons(2) do |prev, item|
+        strip_final_whitespace(prev, open_strip_for(item)) if item.sexp_type != :content
+        strip_initial_whitespace(item, close_strip_for(prev)) if prev.sexp_type != :content
+      end
+    end
+
+    def strip_initial_whitespace(item, strip)
+      item[1] = item[1].sub(/^\s*/, "") if item.sexp_type == :content && strip[2]
+    end
+
+    def strip_final_whitespace(item, strip)
+      item[1] = item[1].sub(/\s*$/, "") if item.sexp_type == :content && strip&.at(1)
+    end
+
+    def open_strip_for(item)
+      case item.sexp_type
+      when :block
+        item.at(-2)
+      else
+        item.last
+      end
+    end
+
+    def close_strip_for(item)
+      item.last
+    end
+  end
+end

--- a/test/support/template_tester.rb
+++ b/test/support/template_tester.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "haparanda/handlebars_parser"
-require "haparanda/whitespace_handler"
 require "haparanda/handlebars_processor"
 
 class TemplateTester


### PR DESCRIPTION
This splits `WhitespaceHandler` into a part for handling 'standalone' blocks and partials (`StandaloneWhitespaceHandler`), and a part for handling the stripping decorations on mustaches (`WhitespaceStripper`).

This means the handling of the `:ignore_standalone` compile-time option can be done entirely inside the `Parser` class, since ignoring standalone means simply not calling the `StandaloneWhitespaceHandler`.
