### PR TITLE
Support use of special path segment names if marked as literal segments

### DIFF
--- a/lib/haparanda/handlebars_parser.y
+++ b/lib/haparanda/handlebars_parser.y
@@ -263,8 +263,7 @@ end
 
 def id(val)
   if (match = /\A\[(.*)\]\Z/.match val)
-    # TODO: Mark as having had square brackets
-    s(:id, match[1])
+    s(:id, match[1], true)
   else
     s(:id, val)
   end
@@ -278,19 +277,19 @@ def interpret_open_token(open)
 end
 
 def prepare_path(data, sexpr, parts, loc)
-  tail = []
+  prefix = []
   parts.each_slice(2) do |part, sep|
     if ["..", ".", "this"].include? part[1]
-      unless tail.empty?
-        path = tail.map { _1[1] }.join + part[1]
+      unless prefix.empty? || part[2]
+        path = prefix.map { _1[1] }.join + part[1]
         # TODO: keep track of the position in the line as well
         raise ParseError, "Invalid path: #{path} - #{loc}"
       end
       next
     end
 
-    tail << part
-    tail << sep if sep
+    prefix << part
+    prefix << sep if sep
   end
   # TODO: Handle sexpr
   s(:path, data, *parts).line loc

--- a/test/compatibility/basic_test.rb
+++ b/test/compatibility/basic_test.rb
@@ -486,7 +486,6 @@ describe 'basic context' do
       'Invalid path: text/this - 1'
     );
 
-    skip
     expectTemplate('{{[this]}}').withInput({ this: 'bar' }).toCompileTo('bar');
 
     expectTemplate('{{text/[this]}}')

--- a/test/integration/basic_test.rb
+++ b/test/integration/basic_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe "basic operations" do
+  let(:compiler) { Haparanda::Compiler.new }
+
+  describe "value lookup" do
+    it "allows 'this' as a regular path component if marked as a literal" do
+      result = compiler.compile("{{[this]}}")
+                       .call({ this: "bar" })
+
+      _(result).must_equal "bar"
+    end
+
+    it "allows '.' as a regular path component if marked as a literal" do
+      result = compiler.compile("{{[.]}}")
+                       .call({ ".": "bar" })
+
+      _(result).must_equal "bar"
+    end
+
+    it "allows '..' as a regular path component if marked as a literal" do
+      result = compiler.compile("{{[..]}}")
+                       .call({ "..": "bar" })
+
+      _(result).must_equal "bar"
+    end
+
+    it "allows 'this' as a regular nested path component if marked as a literal" do
+      result = compiler.compile("{{foo.[this]}}")
+                       .call({ foo: { this: "bar" } })
+
+      _(result).must_equal "bar"
+    end
+
+    it "allows '.' as a regular nested path component if marked as a literal" do
+      result = compiler.compile("{{foo.[.]}}")
+                       .call({ foo: { ".": "bar" } })
+
+      _(result).must_equal "bar"
+    end
+
+    it "allows '..' as a regular nested path component if marked as a literal" do
+      result = compiler.compile("{{foo.[..]}}")
+                       .call({ foo: { "..": "bar" } })
+
+      _(result).must_equal "bar"
+    end
+  end
+end


### PR DESCRIPTION
- **Make PrintingProcessor not require sexp to be consumed**
- **Support use of special path segment names if marked as literal segments**
