### PR TITLE
Update simplecov configuration to the new system

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 SimpleCov.configure do
-  no_default_skips
+  # Remove the "test_frameworks" filter
+  clear_filters
+  load_profile "bundler_filter"
+  load_profile "hidden_filter"
+  load_profile "root_filter"
 
   group "Library" do |file|
     filename = file.project_filename

--- a/.simplecov
+++ b/.simplecov
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
-SimpleCov.start do
-  add_group "Library" do |file|
+SimpleCov.configure do
+  no_default_skips
+
+  group "Library" do |file|
     filename = file.project_filename
-    filename.start_with?("/lib/") &&
-      !["/lib/haparanda/handlebars_lexer.rb",
-        "/lib/haparanda/handlebars_parser.rb"].include?(filename)
+    filename.start_with?("lib/") &&
+      !["lib/haparanda/handlebars_lexer.rb",
+        "lib/haparanda/handlebars_parser.rb"].include?(filename)
   end
-  add_group "Generated Code",
-            ["lib/haparanda/handlebars_lexer.rb", "lib/haparanda/handlebars_parser.rb"]
-  add_group "Tests",
-            ["test/test_helper.rb", "test/support", "test/haparanda", "test/integration"]
-  add_group "Compatibility Tests", "test/compatibility"
-  add_group "Mustache Tests", "test/mustache"
+  group "Generated Code",
+        ["lib/haparanda/handlebars_lexer.rb", "lib/haparanda/handlebars_parser.rb"]
+  group "Tests",
+        ["test/test_helper.rb", "test/support", "test/haparanda", "test/integration"]
+  group "Compatibility Tests", "test/compatibility"
+  group "Mustache Tests", "test/mustache"
   enable_coverage :branch
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "simplecov"
+SimpleCov.start
+
 require "minitest/autorun"
 require "minitest/focus"
 


### PR DESCRIPTION
With simplecov 1.0, using SimpleCov.start in .simplecov is deprecated and there's a new configuration system while the old configuration methods have been deprecated. This changes updates the setup to use the new system.
